### PR TITLE
Improve test coverage for unit test of US-1a and US-3a

### DIFF
--- a/oxytcmri/domain/entities/mri.py
+++ b/oxytcmri/domain/entities/mri.py
@@ -128,6 +128,27 @@ class VoxelData(ABC, Generic[T]):
         """
 
     @abstractmethod
+    def set_value_at(self, x: int, y: int, z: int, value: T) -> None:
+        """
+        Set the value of a voxel at a specific position.
+
+        Parameters
+        ----------
+        x : int
+            x-coordinate of the voxel
+        y : int
+            y-coordinate of the voxel
+        z : int
+            z-coordinate of the voxel
+        value : T
+            Value to set for the voxel
+
+        Returns
+        -------
+        None
+        """
+
+    @abstractmethod
     def get_dimensions(self) -> tuple[int, int, int]:
         """
         Get the dimensions of the voxel data.

--- a/oxytcmri/domain/entities/mri.py
+++ b/oxytcmri/domain/entities/mri.py
@@ -355,13 +355,6 @@ class Mask(MRIData[bool]):
         -------
         List[Tuple[int, int, int]]
             List of (x, y, z) coordinates where the mask has True values
-        
-        Examples
-        --------
-        >>> mask = atlas_segmentation.create_mask([42])
-        >>> coordinates = mask.get_true_voxel_coordinates()
-        >>> print(f"Found {len(coordinates)} voxels in region")
-        Found 1024 voxels in region
         """
         # List to store coordinates
         coordinates = []

--- a/oxytcmri/domain/use_cases/segment_dti_abnormal_values.py
+++ b/oxytcmri/domain/use_cases/segment_dti_abnormal_values.py
@@ -515,4 +515,4 @@ class SegmentDTIAbnormalValues:
             # Check if value is abnormal
             abnormality_type = thresholds.get_abnormality_type(dti_value)
             if abnormality_type:
-                result.mark_voxel_as_abnormal(x, y, z, abnormality_type)
+                result.voxel_data.set_value_at(x, y, z, abnormality_type)

--- a/oxytcmri/domain/use_cases/segment_dti_abnormal_values.py
+++ b/oxytcmri/domain/use_cases/segment_dti_abnormal_values.py
@@ -104,12 +104,9 @@ class AbnormalVoxelData(VoxelData[AbnormalValueType]):
         ValueError
             If coordinates are out of bounds or if voxel is not abnormal
         """
-        if not self._is_in_bounds(x, y, z):
-            raise ValueError(f"Coordinates ({x}, {y}, {z}) out of bounds. Dimensions: {self.dimensions}")
-
         coords = (x, y, z)
         if coords not in self.abnormal_voxels:
-            raise ValueError(f"No abnormal value at coordinates ({x}, {y}, {z})")
+            raise ValueError(f"Coordinates ({x}, {y}, {z}) out of bounds. Dimensions: {self.dimensions}")
 
         return self.abnormal_voxels[coords]
 

--- a/oxytcmri/domain/use_cases/segment_dti_abnormal_values.py
+++ b/oxytcmri/domain/use_cases/segment_dti_abnormal_values.py
@@ -151,9 +151,10 @@ class AbnormalVoxelData(VoxelData[AbnormalValueType]):
         bool
             True if coordinates are valid, False otherwise
         """
-        return (0 <= x < self.dimensions[0] and
-                0 <= y < self.dimensions[1] and
-                0 <= z < self.dimensions[2])
+        x_bound, y_bound, z_bound = self.get_dimensions()
+        return (0 <= x < x_bound and
+                0 <= y < y_bound and
+                0 <= z < z_bound)
 
     def get_dimensions(self) -> Tuple[int, int, int]:
         """

--- a/oxytcmri/interface/mri/voxel_data_adapters.py
+++ b/oxytcmri/interface/mri/voxel_data_adapters.py
@@ -44,6 +44,27 @@ class InMemoryNumpyVoxelData(VoxelData[T]):
         """
         return self._data[x, y, z]
 
+    def set_value_at(self, x: int, y: int, z: int, value: T) -> None:
+        """
+        Set the value of a voxel at a specific position.
+
+        Parameters
+        ----------
+        x : int
+            x-coordinate of the voxel
+        y : int
+            y-coordinate of the voxel
+        z : int
+            z-coordinate of the voxel
+        value : T
+            Value to set for the voxel
+
+        Returns
+        -------
+        None
+        """
+        self._data[x, y, z] = value
+
     def get_dimensions(self) -> Tuple[int, int, int]:
         """Get the dimensions of the voxel data.
 
@@ -159,6 +180,9 @@ class NiftiVoxelData(VoxelData[T]):
             raise ValueError(
                 f"Coordinates ({x}, {y}, {z}) are out of bounds. Shape is {dimensions}"
             )
+
+    def set_value_at(self, x: int, y: int, z: int, value: T) -> None:
+        raise NotImplementedError("Setting values in NIfTI files is not (yet) implemented.")
 
     def get_dimensions(self) -> Tuple[int, int, int]:
         """Get the dimensions of the voxel data.

--- a/oxytcmri/tests/unit/domain/mocks.py
+++ b/oxytcmri/tests/unit/domain/mocks.py
@@ -157,6 +157,10 @@ class MockVoxelData(VoxelData[float]):
     def get_value_at(self, x: int, y: int, z: int) -> float:
         return self.value
 
+    def set_value_at(self, x: int, y: int, z: int, value: float) -> None:
+        """Set the value of a voxel at a specific position."""
+        self.value = value
+
     def get_dimensions(self) -> Tuple[int, int, int]:
         return 10, 10, 10
 
@@ -181,6 +185,9 @@ class MockSegmentationData(VoxelData[int]):
 
     def get_value_at(self, x: int, y: int, z: int) -> int:
         return self.value
+
+    def set_value_at(self, x: int, y: int, z: int, value: int) -> None:
+        raise NotImplementedError("set_value_at is not implemented in MockSegmentationData")
 
     def get_dimensions(self) -> tuple[int, int, int]:
         return 10, 10, 10

--- a/oxytcmri/tests/unit/domain/mocks.py
+++ b/oxytcmri/tests/unit/domain/mocks.py
@@ -7,7 +7,7 @@ from oxytcmri.domain.entities.mri import (
     DTIMetric,
     Atlas,
     MRIExam,
-    VoxelData, AtlasSegmentation, DTIMap, T, MRIExamId, MRIData,
+    VoxelData, AtlasSegmentation, DTIMap, T, MRIExamId, MRIData, Mask,
 )
 from oxytcmri.domain.entities.subject import Subject, SubjectType, SubjectId
 from oxytcmri.domain.ports.repositories import (
@@ -125,7 +125,7 @@ class MockInMemorySubjectRepository(InMemoryRepository[Subject, str], SubjectRep
         ]
 
 
-class MockMaskData(VoxelData[bool]):
+class MockMaskData(Mask):
     """Mock for boolean masks."""
 
     def __init__(self, boolean_value: bool = True):
@@ -134,10 +134,12 @@ class MockMaskData(VoxelData[bool]):
     def get_value_at(self, x: int, y: int, z: int) -> bool:
         return self.boolean_value
 
-    def get_dimensions(self) -> Tuple[int, int, int]:
+    @staticmethod
+    def get_dimensions() -> Tuple[int, int, int]:
         return 10, 10, 10
 
-    def get_voxel_volume_in_ml(self) -> float:
+    @staticmethod
+    def get_voxel_volume_in_ml() -> float:
         return 8.0
 
     def filter_values(self, condition: Callable[[T], bool]) -> VoxelData[bool]:

--- a/oxytcmri/tests/unit/domain/use_cases/test_segment_dti_abnormal_values.py
+++ b/oxytcmri/tests/unit/domain/use_cases/test_segment_dti_abnormal_values.py
@@ -25,24 +25,30 @@ class TestSegmentDTIAbnormalValues:
         """
         Test the segment_dti_map_for_atlas method to ensure it properly identifies and marks
         abnormal voxels. This test specifically focuses on the loop that processes abnormal values
-        and checks if voxels with values outside of thresholds are correctly marked.
+        and checks if voxels with values outside of thresholds are correctly marked as both
+        HIGH and LOW abnormalities.
         """
         # Initialize the use case with mock repositories
         segment_dti = SegmentDTIAbnormalValues(
             MockInMemoryRepositoriesRegistry(),
         )
         
-        # Create a mock DTI VoxelData class that returns abnormal values
+        # Create a mock DTI VoxelData class that returns abnormal values based on coordinates
         class MockDTIVoxelDataWithAbnormalValues(MockVoxelData):
             def get_value_at(self, x: int, y: int, z: int) -> float:
-                # Return a high value that exceeds the default threshold (0.8)
-                return 0.9  
+                # Return HIGH value for first set of coordinates, LOW value for second set
+                if (x, y, z) == (1, 2, 3):
+                    return 0.9  # HIGH value (above 0.8 threshold)
+                elif (x, y, z) == (4, 5, 6):
+                    return 0.2  # LOW value (below 0.3 threshold)
+                else:
+                    return 0.5  # Normal value
         
         # Create a mock mask that returns specific coordinates
         class MockMaskWithCoordinates(MockMaskData):
             def get_true_voxel_coordinates(self):
                 # Return some coordinates for testing
-                return [(1, 2, 3), (4, 5, 6)]
+                return [(1, 2, 3), (4, 5, 6), (7, 8, 9)]  # 3rd set should be normal
         
         # Create a mock atlas segmentation that returns our custom mask
         class MockAtlasSegmentationWithCoordinates(AtlasSegmentation):
@@ -79,10 +85,14 @@ class TestSegmentDTIAbnormalValues:
         # Execute the method being tested
         result = segment_dti.segment_dti_map_for_atlas(dti_image, atlas)
         
-        # Verify that abnormal voxels were detected and marked
-        # Check specifically for coordinates we defined in our mock
-        assert result.voxel_data.is_abnormal(1, 2, 3), "First test coordinate should be marked as abnormal"
-        assert result.voxel_data.is_abnormal(4, 5, 6), "Second test coordinate should be marked as abnormal"
-        
-        # Check the abnormality type
+        # Verify that abnormal voxels were detected and marked correctly
+        # Check HIGH abnormality
+        assert result.voxel_data.is_abnormal(1, 2, 3), "First test coordinate should be marked as abnormal (HIGH)"
         assert result.voxel_data.get_value_at(1, 2, 3) == AbnormalValueType.HIGH, "Expected HIGH abnormality type"
+        
+        # Check LOW abnormality
+        assert result.voxel_data.is_abnormal(4, 5, 6), "Second test coordinate should be marked as abnormal (LOW)"
+        assert result.voxel_data.get_value_at(4, 5, 6) == AbnormalValueType.LOW, "Expected LOW abnormality type"
+        
+        # Check that normal values are not marked as abnormal
+        assert not result.voxel_data.is_abnormal(7, 8, 9), "Third test coordinate should not be marked as abnormal"

--- a/oxytcmri/tests/unit/domain/use_cases/test_segment_dti_abnormal_values.py
+++ b/oxytcmri/tests/unit/domain/use_cases/test_segment_dti_abnormal_values.py
@@ -1,6 +1,9 @@
-from oxytcmri.domain.use_cases.segment_dti_abnormal_values import SegmentDTIAbnormalValues
+from oxytcmri.domain.entities.mri import DTIMap, MRIExamId, DTIMetric, AtlasSegmentation, MRIExam
+from oxytcmri.domain.entities.subject import SubjectId
+from oxytcmri.domain.use_cases.segment_dti_abnormal_values import SegmentDTIAbnormalValues, AbnormalVoxelData, \
+    AbnormalValueType
 from oxytcmri.tests.unit.domain.mocks import (
-    MockInMemoryRepositoriesRegistry
+    MockInMemoryRepositoriesRegistry, MockVoxelData, MockMaskData, MockSegmentationData
 )
 
 
@@ -17,3 +20,69 @@ class TestSegmentDTIAbnormalValues:
 
         # execution
         compute_normative_values()
+
+    def test_segment_dti_map_for_atlas(self):
+        """
+        Test the segment_dti_map_for_atlas method to ensure it properly identifies and marks
+        abnormal voxels. This test specifically focuses on the loop that processes abnormal values
+        and checks if voxels with values outside of thresholds are correctly marked.
+        """
+        # Initialize the use case with mock repositories
+        segment_dti = SegmentDTIAbnormalValues(
+            MockInMemoryRepositoriesRegistry(),
+        )
+        
+        # Create a mock DTI VoxelData class that returns abnormal values
+        class MockDTIVoxelDataWithAbnormalValues(MockVoxelData):
+            def get_value_at(self, x: int, y: int, z: int) -> float:
+                # Return a high value that exceeds the default threshold (0.8)
+                return 0.9  
+        
+        # Create a mock mask that returns specific coordinates
+        class MockMaskWithCoordinates(MockMaskData):
+            def get_true_voxel_coordinates(self):
+                # Return some coordinates for testing
+                return [(1, 2, 3), (4, 5, 6)]
+        
+        # Create a mock atlas segmentation that returns our custom mask
+        class MockAtlasSegmentationWithCoordinates(AtlasSegmentation):
+            def create_mask(self, labels):
+                return MockMaskWithCoordinates()
+        
+        # Create a DTI map with the custom voxel data
+        dti_image = DTIMap(
+            mri_exam_id=MRIExamId("test-exam"),
+            voxel_data=MockDTIVoxelDataWithAbnormalValues(),
+            dti_metric=DTIMetric.FA
+        )
+        
+        # Get an atlas from the repository
+        atlas = segment_dti.atlas_repository.list_all()[0]
+        
+        # Create a mock MRIExam with our custom atlas segmentation
+        mri_exam = MRIExam(
+            id=dti_image.mri_exam_id,
+            subject_id=SubjectId("01-01-T"),
+            data=[
+                MockAtlasSegmentationWithCoordinates(
+                    mri_exam_id=dti_image.mri_exam_id,
+                    voxel_data=MockSegmentationData(),
+                    atlas=atlas
+                )
+            ]
+        )
+        
+        # Override the get_by_id method in mri_repository to return our custom MRIExam
+        original_get_by_id = segment_dti.mri_repository.find_by_id
+        segment_dti.mri_repository.find_by_id = lambda id: mri_exam if id == dti_image.mri_exam_id else original_get_by_id(id)
+        
+        # Execute the method being tested
+        result = segment_dti.segment_dti_map_for_atlas(dti_image, atlas)
+        
+        # Verify that abnormal voxels were detected and marked
+        # Check specifically for coordinates we defined in our mock
+        assert result.voxel_data.is_abnormal(1, 2, 3), "First test coordinate should be marked as abnormal"
+        assert result.voxel_data.is_abnormal(4, 5, 6), "Second test coordinate should be marked as abnormal"
+        
+        # Check the abnormality type
+        assert result.voxel_data.get_value_at(1, 2, 3) == AbnormalValueType.HIGH, "Expected HIGH abnormality type"


### PR DESCRIPTION
Closes #67, and therefore #57 and #61 

This pull request introduces several updates to the `oxytcmri` codebase, focusing on refactoring, functionality improvements, and enhanced testing. Key changes include refactoring methods for better maintainability, updating abnormal voxel marking logic, and adding a new unit test to validate abnormal voxel detection.

### Refactoring and Code Improvements:
* Refactored `_is_in_bounds` in `oxytcmri/domain/use_cases/segment_dti_abnormal_values.py` to use a new `get_dimensions` method for retrieving bounds, improving code readability and maintainability.
* Updated `mark_abnormal_voxels` in `oxytcmri/domain/use_cases/segment_dti_abnormal_values.py` to use `set_value_at` instead of `mark_voxel_as_abnormal` for marking abnormal voxels, aligning with the updated data structure.

### Documentation and Examples:
* Removed example usage from the docstring of `get_true_voxel_coordinates` in `oxytcmri/domain/entities/mri.py` to streamline the documentation.

### Testing Enhancements:
* Added a new test method, `test_segment_dti_map_for_atlas`, in `oxytcmri/tests/unit/domain/use_cases/test_segment_dti_abnormal_values.py` to validate the detection and marking of abnormal voxels. This test introduces mock classes for simulating abnormal voxel data and specific coordinates.
* Updated imports in `oxytcmri/tests/unit/domain/use_cases/test_segment_dti_abnormal_values.py` to include additional entities and mock classes required for the new test.